### PR TITLE
core.py

### DIFF
--- a/PyDictionary/core.py
+++ b/PyDictionary/core.py
@@ -113,7 +113,7 @@ class PyDictionary(object):
                 print("{0} has no Antonyms in the API".format(word))
 
     @staticmethod
-    def meaning(term):
+    def meaning(term, disable_errors=False):
         if len(term.split()) > 1:
             print("Error: A Term must be only a single word")
         else:
@@ -136,7 +136,8 @@ class PyDictionary(object):
                     out[name] = meanings
                 return out
             except Exception as e:
-                print("Error: The Following Error occured: %s" % e)
+                if disable_errors == False:
+                    print("Error: The Following Error occured: %s" % e)
 
     @staticmethod
     def googlemeaning(term, formatted=True):


### PR DESCRIPTION
Added an optional parameter to disable printing an error message when using the `PyDictionary.meaning()` function. 

This error message became troublesome for me when I tried using the referenced function to filter a list of English words for nouns, i.e.:
```python
nouns = []
for word in wordList:
    try:
            x = PyDictionary.meaning(word)
    except:
            continue
    if 'Noun' in x:
            nouns.append(word)
```
The added default parameter in line 116 allows a user to disable the error messages if need be. If not declared `True`, the program will print errors as usual in line 139-140.

Sorry if this is over-explained. This is my first pull request so I'm not sure what the standard for these comments is.