### PR TITLE
Fixed BS html.parser error

### DIFF
--- a/PyDictionary/core.py
+++ b/PyDictionary/core.py
@@ -19,7 +19,7 @@ class PyDictionary(object):
         except:
             self.args = args
 
-        
+
     def printMeanings(self):
         dic = self.getMeanings()
         for key in dic.keys():
@@ -68,7 +68,7 @@ class PyDictionary(object):
             print("Error: A Term must be only a single word")
         else:
             try:
-                data = _get_soup_object("http://www.thesaurus.com/browse/{0}".format(term))
+                data = _get_soup_object("http://www.thesaurus.com/browse/{0}".format(term), "html.parser")
                 terms = data.select("div#filters-0")[0].findAll("li")
                 if len(terms) > 5:
                     terms = terms[:5:]


### PR DESCRIPTION
Really simple, Beautiful Soup was raising an issue about not explicitly specifying an HTML parser.
**brahmcapoor**  did a similar PR, but I don't know if it ever passed travis.

So from:
![screen shot 2018-07-03 at 9 02 40 pm](https://user-images.githubusercontent.com/31192968/42256176-90372816-7f04-11e8-90a5-1b41fea062e8.png)

To:
![screen shot 2018-07-03 at 9 02 56 pm](https://user-images.githubusercontent.com/31192968/42256177-9058a946-7f04-11e8-8dd8-9d132038bdf0.png)

_Please note_ that it still doesn't find the appropriate synonyms.

This is because each listed synonym string is under it's own individual span tag in the markup unfortunately.

But that's for another PR.

Thank you very much! Let me know if I totally blew it.