### PR TITLE
Fix index error while the result of meaning is not found

### DIFF
--- a/PyDictionary/core.py
+++ b/PyDictionary/core.py
@@ -124,6 +124,10 @@ class PyDictionary(object):
                 length = len(types)
                 lists = html.findAll("ul")
                 out = {}
+
+                if 'Your search did not return any results.' in types[0]:
+                    return out
+
                 for a in types:
                     reg = str(lists[types.index(a)])
                     meanings = []


### PR DESCRIPTION
While the input is meaningless, thesaurus.com will return a not found
message. This will cause the part of using reg module to find meanings
raising index error.

I added a statement to determine this situation and directly return
empty output.