### PR TITLE
Fix #35: index error when word is not found

### DIFF
--- a/PyDictionary/core.py
+++ b/PyDictionary/core.py
@@ -122,8 +122,8 @@ class PyDictionary(object):
                 length = len(types)
                 lists = html.findAll("ul")
                 out = {}
-                for a in types:
-                    reg = str(lists[types.index(a)])
+                for a, reg in zip(types, lists):
+                    reg = str(reg)
                     meanings = []
                     for x in re.findall(r'\((.*?)\)', reg):
                         if 'often followed by' in x:


### PR DESCRIPTION
When the word is not found the error message is in an h3 tag. Update to use zip() which ensures a matching ul tag for every h3 tag.