### PR TITLE
Raise error that can be handled by try/except

### DIFF
--- a/PyDictionary/core.py
+++ b/PyDictionary/core.py
@@ -135,7 +135,6 @@ class PyDictionary(object):
                 return out
             except Exception as e:
                 if disable_errors == False:
-                    print("Error: The Following Error occured: %s" % e)
                     raise e
 
 if __name__ == '__main__':

--- a/PyDictionary/core.py
+++ b/PyDictionary/core.py
@@ -136,6 +136,7 @@ class PyDictionary(object):
             except Exception as e:
                 if disable_errors == False:
                     print("Error: The Following Error occured: %s" % e)
+                    raise e
 
 if __name__ == '__main__':
     d = PyDictionary('honest','happy')


### PR DESCRIPTION
Issue #34 refers to the fact that when a word is not found, the console prints an error that cannot be captured. This PR fixes this issue by **raising** an error that can be handled.
